### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,18 +17,18 @@ backward	KEYWORD2
 stop	KEYWORD2
 rotateLeft	KEYWORD2
 rotateRight	KEYWORD2
-leftMotorForward KEYWORD2
-leftMotorBackward KEYWORD2
-leftMotorStop KEYWORD2
-rightMotorForward KEYWORD2
-rightMotorBackward KEYWORD2
-rightMotorStop KEYWORD2
+leftMotorForward	KEYWORD2
+leftMotorBackward	KEYWORD2
+leftMotorStop	KEYWORD2
+rightMotorForward	KEYWORD2
+rightMotorBackward	KEYWORD2
+rightMotorStop	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-Motor KEYWORD2
+Motor	KEYWORD2
 Rover	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords